### PR TITLE
Epic/EP-1086: Missing column repeat_time_zone and adding default timezone as UTC

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -55,7 +55,7 @@ Job.prototype.toJSON = function() { // create a persistable Mongo object -RR
 Job.prototype.computenext_run_at = function() {
   var interval = this.attrs.repeat_interval;
   var repeatAt = this.attrs.repeatAt;
-  var timezone = this.attrs.repeatTimezone;
+  var timezone = this.attrs.repeat_time_zone;
   this.attrs.next_run_at = null; //undefined;
 
   if (interval) {
@@ -117,7 +117,7 @@ Job.prototype.computenext_run_at = function() {
 Job.prototype.repeatEvery = function(interval, options) {
   options = options || {};
   this.attrs.repeat_interval = interval;
-  this.attrs.repeatTimezone = options.timezone ? options.timezone : null;
+  this.attrs.repeat_time_zone = options.timezone ? options.timezone : 'UTC';
   return this;
 };
 


### PR DESCRIPTION
Missing column repeat_time_zone and adding default timezone as UTC
